### PR TITLE
Pure JSON code

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,8 @@ kle.Serial.deserialize(rows: Array<any>): Keyboard
 - The first entry is optionally a keyboard metadata object.
 
 ```ts
-kle.Serial.parse(json5: string): Keyboard
+kle.Serial.parse(json: string): Keyboard
 ```
-
-- This function takes a JSON5-formatted string, parses it, then deserializes the
-  result into a `Keyboard` object.
-- [JSON5](https://json5.org/) is a simplified / lenient version of JSON that is
-  easier for humans to type; in particular, it doesn't require quotes around
-  property names. Any valid JSON string should also be a valid JSON5 string.
 
 ### Keyboard Objects
 

--- a/package.json
+++ b/package.json
@@ -27,14 +27,10 @@
   },
   "homepage": "https://github.com/qmk-helper/kle-serial/#readme",
   "devDependencies": {
-    "@types/json5": "0.0.30",
     "chai": "^4.2.0",
     "coveralls": "^3.1.0",
     "mocha": "^8.1.3",
-    "typescript": "^3.9.7",
-    "nyc": "^15.1.0"
-  },
-  "dependencies": {
-    "json5": "^2.1.3"
+    "nyc": "^15.1.0",
+    "typescript": "^3.9.7"
   }
 }

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -1,9 +1,8 @@
-import * as JSON5 from "json5";
 import { labelMap } from "./helper";
 import { Key, Keyboard } from "./interfaces";
 
 function deserializeError(msg, data?) {
-  throw "Error: " + msg + (data ? ":\n  " + JSON5.stringify(data) : "");
+  throw "Error: " + msg + (data ? ":\n  " + JSON.stringify(data) : "");
 }
 
 // Map from serialized label position to normalized position,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import * as JSON5 from "json5";
 import { deserialize } from "./deserialize";
 import { Keyboard } from "./interfaces";
 import { serialize } from "./serialize";
@@ -12,7 +11,7 @@ export {
 export { serialize } from "./serialize";
 
 export function parse(json: string): Keyboard {
-  return deserialize(JSON5.parse(json));
+  return deserialize(JSON.parse(json));
 }
 export function stringify(keyboard: Keyboard): string {
   return JSON.stringify(serialize(keyboard));

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,4 +1,3 @@
-import * as JSON5 from "json5";
 import { labelMap } from "./helper";
 import { Key, Keyboard, KeyboardMetadata } from "./interfaces";
 
@@ -10,7 +9,7 @@ function serializeProp(props, nname, val, defval) {
   return val;
 }
 function serializeError(msg: string, data?: any) {
-  throw "Error: " + msg + (data ? ":\n  " + JSON5.stringify(data) : "");
+  throw "Error: " + msg + (data ? ":\n  " + JSON.stringify(data) : "");
 }
 function isEmptyObject(o) {
   for (var prop in o) return false;


### PR DESCRIPTION
Folks wanting JSON5 handling for their data can
add that in their application layer. This removes
the one dependency this project had, making it much
more sustainable, simpler, and faster. Huzzah!

I sent a similar series of commits (which also remove `.parse()` which feels unnecessary as a core method) to the upstream project (fwiw...):
https://github.com/ijprest/kle-serial/pull/12

Thanks for adding the serialization capabilities!
🎩 